### PR TITLE
Add a check to test if langs is null, Fix issue #1

### DIFF
--- a/AssemblyResolver.cs
+++ b/AssemblyResolver.cs
@@ -174,7 +174,7 @@ namespace Okin
             var langs = openExeConfiguration == null
                             ? ConfigurationManager.AppSettings["LanguagesDirectories"]
                             : openExeConfiguration.AppSettings.Settings["LanguagesDirectories"].Value;
-            if (this.languagesDirectories != null)
+            if (this.languagesDirectories != null && langs != null)
                 this.languagesDirectories.AddRange(langs.Split(';'));
         }
 


### PR DESCRIPTION
If the user does not provide a LanguagesDirectories configuration entry, langs will be null and it will throw a NPE.
Adds a check that prevent the NPE.

Fix issue #1